### PR TITLE
Update uart_11xx.c

### DIFF
--- a/lpc_chip_11exx/src/uart_11xx.c
+++ b/lpc_chip_11exx/src/uart_11xx.c
@@ -252,6 +252,7 @@ uint32_t Chip_UART_SetBaudFDR(LPC_USART_T *pUART, uint32_t baudrate)
 	 * new_mval = mval / dval
 	 * new_dval = 1
 	 */
+	mval = rate16;
 	if (dval > 0) {
 		mval = rate16 / dval;
 		dval = 1;


### PR DESCRIPTION
Fixes following warning:
../src/uart_11xx.c:267:7: warning: 'mval' may be used uninitialized in this function [-Wmaybe-uninitialized]

I don't know this code. [mval = rate16;] is only a guess.